### PR TITLE
[Fix] Fetch duplicated php versions

### DIFF
--- a/src/actions/install.ps1
+++ b/src/actions/install.ps1
@@ -43,9 +43,9 @@ function Get-PHP-Versions {
                 $sysArch = if ($env:PROCESSOR_ARCHITECTURE -eq 'AMD64') { 'x64' } else { 'x86' }
                 $fetched = $fetched | Where-Object { $_.href -match "$sysArch" }
 
-                if ($found -notcontains $fetched.version) {
+                if ($found -notcontains $fetched.fileName) {
                     $fetchedVersions += $fetched | Select-Object -Last 5
-                    $found += $fetchedVersions |ForEach-Object { $_.version }
+                    $found += $fetchedVersions |ForEach-Object { $_.fileName }
                 }
             }
         }


### PR DESCRIPTION
When I tried to install php-7.4.33, I got message to specify an exact version. This was due to duplicate php version in Archives and Releases.

So to fix this I made sure that we got only unique versions, and I thought that the user does not need to know if it's coming from Archives or Releases as it's the same thing, so I removed that categorisation when it's displayed on terminal.


