### PR TITLE
Fix `Is-PHP-Version-Installed` false positive

### DIFF
--- a/src/actions/common.ps1
+++ b/src/actions/common.ps1
@@ -48,7 +48,7 @@ function Get-Matching-PHP-Versions {
                 $matchingVersions += ($v -replace 'php', '')
             }
         }
-        
+
         return $matchingVersions
     }
     catch {
@@ -63,7 +63,7 @@ function Is-PHP-Version-Installed {
 
     try {
         $installedVersions = Get-Matching-PHP-Versions -version $version
-        return ($installedVersions -and $installedVersions.Count -gt 0)
+        return ($installedVersions -contains $version)
     }
     catch {
         $logged = Log-Data -logPath $LOG_ERROR_PATH -message "Is-PHP-Version-Installed: Failed to check if PHP version $version is installed" -data $_.Exception.Message


### PR DESCRIPTION
When you check a non installed matched php version, `Is-PHP-Version-Installed` returns true.

I have `php-7.4.33` installed and `php-7.4.3` not installed.

### The Issue
`Is-PHP-Version-Installed -version 7.4.33` => true.
`Is-PHP-Version-Installed -version 7.4.3` => true.

### Fixed
`Is-PHP-Version-Installed -version 7.4.33` => true.
`Is-PHP-Version-Installed -version 7.4.3` => false.